### PR TITLE
Setting Oauth2 client auth_scheme to :request_body

### DIFF
--- a/lib/omniauth/strategies/etsy.rb
+++ b/lib/omniauth/strategies/etsy.rb
@@ -27,6 +27,7 @@ module OmniAuth
       def setup_phase
         options.scope = preprocessed_scopes
         options.client_options.merge!(urls)
+        options.client_options.merge!(auth_scheme: :request_body)
         super
       end
 


### PR DESCRIPTION
By default Oauth2 client auth_scheme is set to be `:basic_auth`, this causes missing `client_id` in request body and introduces unnecessary `Basic Auth` Authentication header via OAuth2::Authenticator (oauth2-2.0.9/lib/oauth2/authenticator.rb#26)

Setting client_options[:auth_scheme] to `:request_body` fixes this behaviour.

Please let me know if you have any questions or concerns.